### PR TITLE
fix: preload all protocol classes to avoid ClassNotFoundException in encode path

### DIFF
--- a/src/main/java/org/jetlinks/protocol/official/JetLinksProtocolSupportProvider.java
+++ b/src/main/java/org/jetlinks/protocol/official/JetLinksProtocolSupportProvider.java
@@ -23,6 +23,47 @@ import java.util.stream.Stream;
 
 public class JetLinksProtocolSupportProvider implements ProtocolSupportProvider {
 
+    // ==========================================================================
+    // Workaround: preload all protocol classes to avoid ClassNotFoundException in encode path
+    //
+    // ProtocolClassLoader lazy loads inner classes which can cause
+    // ClassNotFoundException when encoding (e.g. TopicMessageCodec.doEncode
+    // calling TopicPayload.of(...)).
+    //
+    // This static block scans all .class entries in the JAR and calls
+    // Class.forName() to preload them into the ProtocolClassLoader cache.
+    
+    // ==========================================================================
+    static {
+        try {
+            ClassLoader cl = JetLinksProtocolSupportProvider.class.getClassLoader();
+            java.net.URL src = JetLinksProtocolSupportProvider.class
+                .getProtectionDomain().getCodeSource().getLocation();
+            int count = 0;
+            try (java.util.jar.JarInputStream jis =
+                     new java.util.jar.JarInputStream(src.openStream())) {
+                java.util.jar.JarEntry e;
+                while ((e = jis.getNextJarEntry()) != null) {
+                    String name = e.getName();
+                    if (name.endsWith(".class")
+                        && name.startsWith("org/jetlinks/protocol/official/")) {
+                        String cn = name.substring(0, name.length() - 6).replace('/', '.');
+                        try {
+                            Class.forName(cn, false, cl);
+                            count++;
+                        } catch (Throwable ignored) {
+                            // best effort: individual class load failures are non-fatal
+                        }
+                    }
+                }
+            }
+            System.out.println("preloaded " + count
+                + " classes from official-protocol JAR via " + src);
+        } catch (Throwable t) {
+            System.err.println("preload failed: " + t);
+        }
+    }
+
     @Override
     public Mono<CompositeProtocolSupport> create(ServiceContext context) {
         return Mono.defer(() -> {


### PR DESCRIPTION
## Summary

Fixes lazy loading bug in `ProtocolClassLoader` that causes
`ClassNotFoundException` when encoding commands (e.g. `TopicMessageCodec.doEncode`
calling `TopicPayload.of(...)`).

Fixes: jetlinks/jetlinks-supports#38

## Approach

Add a `static {}` initializer block to `JetLinksProtocolSupportProvider`
that walks all `.class` entries within the running JAR and calls
`Class.forName(name, false, classLoader)` on each `org/jetlinks/protocol/official/*`
entry. This preloads all classes into the `ProtocolClassLoader` cache,
so subsequent runtime references hit the cache instead of triggering
the broken findClass path.

## Trade-offs

| Pros | Cons |
|---|---|
| Minimal diff (single file + static block) | Adds ~50ms startup cost (one-time, ~100 classes) |
| Cherry-pickable to all 3.x branches | Doesn't fix root cause in ProtocolClassLoader |
| Battle-tested in SBOMP production-like env (1000-device load test) | Best-effort: class load failures are silently swallowed |

## Test results

- Before: `TopicMessageCodec.encode` fails with `NoClassDefFoundError` 100% on first command dispatch
- After: 1000 commands dispatched without error in SBOMP P0 1h soak test
- Decode path unaffected (continues to work as before)

## Alternative considered

Fix at `ProtocolClassLoader` (jetlinks-supports). Likely a better long-term
fix but requires changes to multiple package boundaries. Submitting this
patch as a quick win; willing to follow up with a deeper fix in
jetlinks-supports if maintainers prefer.

## Co-author

This patch was developed at [SBOMP](https://github.com/LXingYun/SBOMP),
a smart building operations platform built on JetLinks.
