### PR TITLE
feat(protocol): 官方协议支持设备模块Topic

### DIFF
--- a/src/main/java/org/jetlinks/protocol/official/JetLinksTopicMessageCodec.java
+++ b/src/main/java/org/jetlinks/protocol/official/JetLinksTopicMessageCodec.java
@@ -1,0 +1,480 @@
+package org.jetlinks.protocol.official;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.jetlinks.core.message.*;
+import org.jetlinks.core.message.collector.*;
+import org.jetlinks.core.message.event.EventMessage;
+import org.jetlinks.core.message.firmware.*;
+import org.jetlinks.core.message.function.FunctionInvokeMessage;
+import org.jetlinks.core.message.function.FunctionInvokeMessageReply;
+import org.jetlinks.core.message.module.DeviceModuleMessage;
+import org.jetlinks.core.message.property.*;
+import org.jetlinks.core.message.state.DeviceStateCheckMessage;
+import org.jetlinks.core.message.state.DeviceStateCheckMessageReply;
+import org.jetlinks.core.route.MqttRoute;
+import org.jetlinks.core.utils.TopicUtils;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.function.Function;
+
+public enum JetLinksTopicMessageCodec {
+    //上报属性数据
+    reportProperty("/properties/report",
+                   ReportPropertyMessage.class,
+                   route -> route
+                       .upstream(true)
+                       .downstream(false)
+                       .group("属性上报")
+                       .description("上报物模型属性数据")
+                       .example("{\"properties\":{\"属性ID\":\"属性值\"}}")),
+    //读取属性
+    readProperty("/properties/read",
+                 ReadPropertyMessage.class,
+                 route -> route
+                     .upstream(false)
+                     .downstream(true)
+                     .group("读取属性")
+                     .description("平台下发读取物模型属性数据指令")
+                     .example("{\"messageId\":\"消息ID,回复时需要一致.\",\"properties\":[\"属性ID\"]}")),
+    //读取属性回复
+    readPropertyReply("/properties/read/reply",
+                      ReadPropertyMessageReply.class,
+                      route -> route
+                          .upstream(true)
+                          .downstream(false)
+                          .group("读取属性")
+                          .description("对平台下发的读取属性指令进行响应")
+                          .example("{\"messageId\":\"消息ID,与读取指令中的ID一致.\",\"properties\":{\"属性ID\":\"属性值\"}}")),
+    //修改属性
+    writeProperty("/properties/write",
+                  WritePropertyMessage.class,
+                  route -> route
+                      .upstream(false)
+                      .downstream(true)
+                      .group("修改属性")
+                      .description("平台下发修改物模型属性数据指令")
+                      .example("{\"messageId\":\"消息ID,回复时需要一致.\",\"properties\":{\"属性ID\":\"属性值\"}}")),
+    //修改属性回复
+    writePropertyReply("/properties/write/reply",
+                       WritePropertyMessageReply.class,
+                       route -> route
+                           .upstream(true)
+                           .downstream(false)
+                           .group("修改属性")
+                           .description("对平台下发的修改属性指令进行响应")
+                           .example("{\"messageId\":\"消息ID,与修改指令中的ID一致.\",\"properties\":{\"属性ID\":\"属性值\"}}")),
+    //事件上报
+    event("/event/*",
+          EventMessage.class,
+          route -> route
+              .upstream(true)
+              .downstream(false)
+              .group("事件上报")
+              .description("上报物模型事件数据")
+              .example("{\"data\":{\"key\":\"value\"}}")) {
+        @Override
+        protected void transMqttTopic(String[] topic) {
+            topic[topic.length - 1] = "{eventId:事件ID}";
+        }
+
+        @Override
+        DeviceMessage doDecode(ObjectMapper mapper, String[] topic, byte[] payload) {
+            String event = topic[topic.length - 1];
+
+            EventMessage message = (EventMessage) super.doDecode(mapper, topic, payload);
+            message.setEvent(event);
+            return message;
+        }
+
+        @Override
+        void refactorTopic(String[] topics, DeviceMessage message) {
+            super.refactorTopic(topics, message);
+            EventMessage event = ((EventMessage) message);
+            topics[topics.length - 1] = String.valueOf(event.getEvent());
+        }
+    },
+
+    //调用功能
+    functionInvoke("/function/invoke",
+                   FunctionInvokeMessage.class,
+                   route -> route
+                       .upstream(false)
+                       .downstream(true)
+                       .group("调用功能")
+                       .description("平台下发功能调用指令")
+                       .example("{\"messageId\":\"消息ID,回复时需要一致.\"," +
+                                    "\"functionId\":\"功能标识\"," +
+                                    "\"inputs\":[{\"name\":\"参数名\",\"value\":\"参数值\"}]}")),
+    //调用功能回复
+    functionInvokeReply("/function/invoke/reply",
+                        FunctionInvokeMessageReply.class,
+                        route -> route
+                            .upstream(true)
+                            .downstream(false)
+                            .group("调用功能")
+                            .description("设备响应平台下发的功能调用指令")
+                            .example("{\"messageId\":\"消息ID,与下发指令中的messageId一致.\"," +
+                                         "\"output\":\"输出结果,格式与物模型中定义的类型一致\"")),
+    //子设备消息
+    child("/child/*/**",
+          ChildDeviceMessage.class,
+          route -> route
+              .upstream(true)
+              .downstream(true)
+              .group("子设备消息")
+              .description("网关上报或者平台下发子设备消息")) {
+        @Override
+        protected void transMqttTopic(String[] topic) {
+            topic[topic.length - 1] = "{#:子设备相应操作的topic}";
+            topic[topic.length - 2] = "{childDeviceId:子设备ID}";
+        }
+
+        @Override
+        public DeviceMessage doDecode(ObjectMapper mapper, String[] topic, byte[] payload) {
+            // /child/{childDeviceId}/{topic...}
+            DeviceMessage childMsg = decodeWrappedInner(mapper, topic, payload, 2);
+            if (childMsg != null) {
+                ChildDeviceMessage msg = new ChildDeviceMessage();
+                msg.setDeviceId(topic[1]);
+                msg.setChildDeviceMessage(childMsg);
+                msg.setTimestamp(childMsg.getTimestamp());
+                msg.setMessageId(childMsg.getMessageId());
+                return msg;
+            }
+            return null;
+        }
+
+        @Override
+        protected TopicPayload doEncode(ObjectMapper mapper, String[] topics, DeviceMessage message) {
+            ChildDeviceMessage deviceMessage = ((ChildDeviceMessage) message);
+
+            DeviceMessage childMessage = (DeviceMessage) deviceMessage.getChildDeviceMessage();
+
+            TopicPayload payload = JetLinksTopicMessageCodec.encode(mapper, childMessage);
+            String[] childTopic = payload.getTopic().split("/");
+            // childTopic[0] is ""
+            // childTopic: ["", "properties", "report"]
+
+            // topics: ["", "child", "{childDeviceId}", "{topic...}"]
+            // 我们需要构建 ["", "child", childDeviceId, "properties", "report"]
+
+            String[] topic = new String[2 + childTopic.length - 1];
+            topic[0] = "";
+            topic[1] = "child";
+            topic[2] = childMessage.getDeviceId(); // 默认使用子设备ID
+            System.arraycopy(childTopic, 1, topic, 3, childTopic.length - 1);
+
+            // 如果ChildDeviceMessage中有设置子设备ID, 则覆盖之
+            if(deviceMessage.getChildDeviceId() != null){
+                topic[2] = deviceMessage.getChildDeviceId();
+            }
+
+            payload.setTopic(String.join("/", topic));
+            return payload;
+        }
+    },
+    //设备模块消息
+    module("/module/*/**",
+           DeviceModuleMessage.class,
+           route -> route
+               .upstream(true)
+               .downstream(true)
+               .group("设备模块消息")
+               .description("设备模块上报或者平台下发模块消息")) {
+        @Override
+        protected void transMqttTopic(String[] topic) {
+            topic[topic.length - 1] = "{#:模块相应操作的topic}";
+            topic[topic.length - 2] = "{module:模块编码}";
+        }
+
+        @Override
+        public DeviceMessage doDecode(ObjectMapper mapper, String[] topic, byte[] payload) {
+            if (topic.length < 4) {
+                return null;
+            }
+            DeviceMessage inner = decodeWrappedInner(mapper, topic, payload, 3);
+            if (inner != null) {
+                DeviceModuleMessage msg = new DeviceModuleMessage();
+                msg.module(topic[2]);
+                msg.message(inner);
+                msg.setTimestamp(inner.getTimestamp());
+                msg.setMessageId(inner.getMessageId());
+                return msg;
+            }
+            return null;
+        }
+
+        @Override
+        protected TopicPayload doEncode(ObjectMapper mapper, String[] topics, DeviceMessage message) {
+            DeviceModuleMessage deviceMessage = ((DeviceModuleMessage) message);
+            if (!(deviceMessage.getMessage() instanceof DeviceMessage)) {
+                throw new UnsupportedOperationException("unsupported module message:" + deviceMessage.getMessage());
+            }
+            DeviceMessage inner = (DeviceMessage) deviceMessage.getMessage();
+            TopicPayload payload = JetLinksTopicMessageCodec.encode(mapper, inner);
+            String[] innerTopic = payload.getTopic().split("/");
+
+            String[] topic = new String[innerTopic.length + 2];
+            topic[0] = "";
+            topic[1] = "module";
+            topic[2] = deviceMessage.getModule();
+            System.arraycopy(innerTopic, 1, topic, 3, innerTopic.length - 1);
+
+            payload.setTopic(String.join("/", topic));
+            return payload;
+        }
+    }, //子设备消息回复
+    childReply("/child-reply/*/**",
+               ChildDeviceMessageReply.class,
+               route -> route
+                   .upstream(true)
+                   .downstream(true)
+                   .group("子设备消息")
+                   .description("网关回复平台下发给子设备的指令结果")) {
+        @Override
+        protected void transMqttTopic(String[] topic) {
+            topic[topic.length - 1] = "{#:子设备相应操作的topic}";
+            topic[topic.length - 2] = "{childDeviceId:子设备ID}";
+        }
+
+        @Override
+        public DeviceMessage doDecode(ObjectMapper mapper, String[] topic, byte[] payload) {
+            DeviceMessage childMsg = decodeWrappedInner(mapper, topic, payload, 2);
+            if (childMsg != null) {
+                ChildDeviceMessageReply msg = new ChildDeviceMessageReply();
+                msg.setDeviceId(topic[1]);
+                msg.setChildDeviceMessage(childMsg);
+                msg.setTimestamp(childMsg.getTimestamp());
+                msg.setMessageId(childMsg.getMessageId());
+                return msg;
+            }
+            return null;
+        }
+
+        @Override
+        protected TopicPayload doEncode(ObjectMapper mapper, String[] topics, DeviceMessage message) {
+            ChildDeviceMessageReply deviceMessage = ((ChildDeviceMessageReply) message);
+
+            DeviceMessage childMessage = (DeviceMessage) deviceMessage.getChildDeviceMessage();
+
+            TopicPayload payload = JetLinksTopicMessageCodec.encode(mapper, childMessage);
+            String[] childTopic = payload.getTopic().split("/");
+
+            String[] topic = new String[2 + childTopic.length - 1];
+            topic[0] = "";
+            topic[1] = "child-reply";
+            topic[2] = childMessage.getDeviceId();
+            System.arraycopy(childTopic, 1, topic, 3, childTopic.length - 1);
+
+            if(deviceMessage.getChildDeviceId() != null){
+                topic[2] = deviceMessage.getChildDeviceId();
+            }
+
+            payload.setTopic(String.join("/", topic));
+            return payload;
+        }
+    },
+    //更新标签
+    updateTag("/tags",
+              UpdateTagMessage.class,
+              route -> route.upstream(true)
+                            .downstream(false)
+                            .group("更新标签")
+                            .description("更新标签数据")
+                            .example("{\"tags\":{\"key\",\"value\"}}")),
+//    //注册
+//    register("/register", DeviceRegisterMessage.class),
+//    //注销
+//    unregister("/unregister", DeviceUnRegisterMessage.class),
+    //更新固件消息
+    upgradeFirmware("/firmware/upgrade", UpgradeFirmwareMessage.class),
+    //更新固件消息回复
+    upgradeFirmwareReply("/firmware/upgrade/reply", UpgradeFirmwareMessageReply.class),
+    //更新固件升级进度消息
+    upgradeProcessFirmware("/firmware/upgrade/progress", UpgradeFirmwareProgressMessage.class),
+    //拉取固件
+    requestFirmware("/firmware/pull", RequestFirmwareMessage.class),
+    //拉取固件更新回复
+    requestFirmwareReply("/firmware/pull/reply", RequestFirmwareMessageReply.class),
+    //上报固件版本
+    reportFirmware("/firmware/report", ReportFirmwareMessage.class),
+    //读取固件回复
+    readFirmware("/firmware/read", ReadFirmwareMessage.class),
+    //读取固件回复
+    readFirmwareReply("/firmware/read/reply", ReadFirmwareMessageReply.class),
+    //派生物模型上报
+    derivedMetadata("/metadata/derived", DerivedMetadataMessage.class),
+    //透传设备消息
+    direct("/direct", DirectDeviceMessage.class) {
+        @Override
+        public DirectDeviceMessage doDecode(ObjectMapper mapper, String[] topic, byte[] payload) {
+            DirectDeviceMessage message = new DirectDeviceMessage();
+            message.setPayload(payload);
+            return message;
+        }
+    },
+    //断开连接消息
+    disconnect("/disconnect", DisconnectDeviceMessage.class),
+    //断开连接回复
+    disconnectReply("/disconnect/reply", DisconnectDeviceMessageReply.class),
+    //上线
+    online("/online", DeviceOnlineMessage.class, builder -> builder
+        .upstream(true)
+        .group("状态管理")
+        .description("设备上线")),
+    //离线
+    offline("/offline", DeviceOfflineMessage.class, builder -> builder
+        .upstream(true)
+        .group("状态管理")
+        .description("设备离线")),
+    //日志
+    log("/log", DeviceLogMessage.class),
+    //状态检查
+    stateCheck("/state-check", DeviceStateCheckMessage.class),
+    stateCheckReply("/state-check/reply", DeviceStateCheckMessageReply.class),
+
+    //数采相关
+    collector("/collector/report", ReportCollectorDataMessage.class
+        , builder -> builder
+        .upstream(true)
+        .group("数采网关")
+        .description("上报数采点位数据")),
+    collectorRead("/collector/read",
+                  ReadCollectorDataMessage.class,
+                  builder -> builder
+                      .downstream(true)
+                      .group("数采网关")
+                      .description("平台读取点位数据")),
+    collectorReadReply("/collector/read/reply",
+                       ReadCollectorDataMessageReply.class,
+                       builder -> builder
+                           .upstream(true)
+                           .group("数采网关")
+                           .description("平台读取点位数据结果回复")),
+    collectorWrite("/collector/write", WriteCollectorDataMessage.class,
+                   builder -> builder
+                       .downstream(true)
+                       .group("数采网关")
+                       .description("平台修改点位数据")),
+    collectorWriteReply("/collector/write/reply", WriteCollectorDataMessageReply.class,
+                        builder -> builder
+                            .upstream(true)
+                            .group("数采网关")
+                            .description("平台修改点位数据结果回复")),
+    ;
+
+    JetLinksTopicMessageCodec(String topic,
+                              Class<? extends DeviceMessage> type,
+                              Function<MqttRoute.Builder, MqttRoute.Builder> routeCustom) {
+        this.pattern = topic.split("/");
+        this.type = type;
+        this.route = routeCustom.apply(toRoute()).build();
+    }
+
+    JetLinksTopicMessageCodec(String topic,
+                              Class<? extends DeviceMessage> type) {
+        this.pattern = topic.split("/");
+        this.type = type;
+        this.route = null;
+    }
+
+    private final String[] pattern;
+    private final MqttRoute route;
+    private final Class<? extends DeviceMessage> type;
+
+    protected void transMqttTopic(String[] topic) {
+
+    }
+
+    @SneakyThrows
+    private MqttRoute.Builder toRoute() {
+        String[] topics = new String[pattern.length];
+        System.arraycopy(pattern, 0, topics, 0, pattern.length);
+        transMqttTopic(topics);
+        StringJoiner joiner = new StringJoiner("/", "/", "");
+        for (String topic : topics) {
+            if(!topic.isEmpty()){
+               joiner.add(topic);
+            }
+        }
+        return MqttRoute
+            .builder(joiner.toString())
+            .qos(1);
+    }
+
+    public MqttRoute getRoute() {
+        return route;
+    }
+
+    public static DeviceMessage decode(ObjectMapper mapper, String[] topics, byte[] payload) {
+        JetLinksTopicMessageCodec codec = fromTopic(topics).orElse(null);
+
+        if (codec != null) {
+            return codec.doDecode(mapper, topics, payload);
+        }
+
+        return null;
+    }
+
+    public static DeviceMessage decode(ObjectMapper mapper, String topic, byte[] payload) {
+        return decode(mapper, topic.split("/"), payload);
+    }
+
+    public static TopicPayload encode(ObjectMapper mapper, DeviceMessage message) {
+
+        return fromMessage(message)
+            .orElseThrow(() -> new UnsupportedOperationException("unsupported message:" + message.getMessageType()))
+            .doEncode(mapper, message);
+    }
+
+    static Optional<JetLinksTopicMessageCodec> fromTopic(String[] topic) {
+        for (JetLinksTopicMessageCodec value : values()) {
+            if (TopicUtils.match(value.pattern, topic)) {
+                return Optional.of(value);
+            }
+        }
+        return Optional.empty();
+    }
+
+    static Optional<JetLinksTopicMessageCodec> fromMessage(DeviceMessage message) {
+        for (JetLinksTopicMessageCodec value : values()) {
+            if (value.type == message.getClass()) {
+                return Optional.of(value);
+            }
+        }
+        return Optional.empty();
+    }
+
+
+    private static DeviceMessage decodeWrappedInner(ObjectMapper mapper, String[] topic, byte[] payload, int innerStart) {
+        String[] inner = Arrays.copyOfRange(topic, innerStart, topic.length);
+        String[] topicToDecode = new String[inner.length + 1];
+        topicToDecode[0] = "";
+        System.arraycopy(inner, 0, topicToDecode, 1, inner.length);
+        return JetLinksTopicMessageCodec.decode(mapper, topicToDecode, payload);
+    }
+
+    @SneakyThrows
+    DeviceMessage doDecode(ObjectMapper mapper, String[] topic, byte[] payload) {
+        return mapper.readValue(payload, type);
+    }
+
+    @SneakyThrows
+    TopicPayload doEncode(ObjectMapper mapper, String[] topics, DeviceMessage message) {
+        refactorTopic(topics, message);
+        return TopicPayload.of(String.join("/", topics), mapper.writeValueAsBytes(message));
+    }
+
+    @SneakyThrows
+    TopicPayload doEncode(ObjectMapper mapper, DeviceMessage message) {
+        String[] topics = Arrays.copyOf(pattern, pattern.length);
+        return doEncode(mapper, topics, message);
+    }
+
+    void refactorTopic(String[] topics, DeviceMessage message) {
+    }
+
+}

--- a/src/test/java/org/jetlinks/protocol/official/TopicMessageCodecTest.java
+++ b/src/test/java/org/jetlinks/protocol/official/TopicMessageCodecTest.java
@@ -4,11 +4,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jetlinks.core.message.ChildDeviceMessage;
 import org.jetlinks.core.message.DeviceMessage;
 import org.jetlinks.core.message.event.EventMessage;
+import org.jetlinks.core.message.function.FunctionInvokeMessage;
+import org.jetlinks.core.message.function.FunctionInvokeMessageReply;
+import org.jetlinks.core.message.module.DeviceModuleMessage;
 import org.jetlinks.core.message.property.ReportPropertyMessage;
+import org.jetlinks.core.message.property.ReadPropertyMessage;
+import org.jetlinks.core.message.property.ReadPropertyMessageReply;
+import org.jetlinks.core.message.property.WritePropertyMessage;
+import org.jetlinks.core.message.property.WritePropertyMessageReply;
 import org.jetlinks.core.route.Route;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -72,4 +81,76 @@ public class TopicMessageCodecTest {
                 .decode(ObjectMappers.JSON_MAPPER, payload.getTopic(), payload.getPayload());
         assertEquals(msg.toJson(), eventMessage.toJson());
     }
+
+    @Test
+    public void testModuleReadWriteAndFunction() {
+        ReadPropertyMessage read = new ReadPropertyMessage();
+        read.deviceId("test-device");
+        read.messageId("msg-read");
+        read.addProperties("temperature");
+
+        DeviceModuleMessage readModule = moduleMessage("board", read, "msg-read");
+        TopicPayload readPayload = JetLinksTopicMessageCodec.encode(ObjectMappers.JSON_MAPPER, readModule);
+        assertEquals("/module/board/properties/read", readPayload.getTopic());
+        DeviceModuleMessage decodedRead = (DeviceModuleMessage) JetLinksTopicMessageCodec.decode(ObjectMappers.JSON_MAPPER, readPayload.getTopic(), readPayload.getPayload());
+        assertEquals("board", decodedRead.getModule());
+        assertEquals("msg-read", decodedRead.getMessageId());
+        assertTrue(decodedRead.getMessage() instanceof ReadPropertyMessage);
+        assertEquals("msg-read", ((ReadPropertyMessage) decodedRead.getMessage()).getMessageId());
+
+        WritePropertyMessage write = new WritePropertyMessage();
+        write.deviceId("test-device");
+        write.messageId("msg-write");
+        write.setProperties(Map.of("threshold", 80));
+        TopicPayload writePayload = JetLinksTopicMessageCodec.encode(ObjectMappers.JSON_MAPPER, moduleMessage("board", write, "msg-write"));
+        assertEquals("/module/board/properties/write", writePayload.getTopic());
+        DeviceModuleMessage decodedWrite = (DeviceModuleMessage) JetLinksTopicMessageCodec.decode(ObjectMappers.JSON_MAPPER, writePayload.getTopic(), writePayload.getPayload());
+        assertTrue(decodedWrite.getMessage() instanceof WritePropertyMessage);
+        assertEquals(80, ((Number) ((WritePropertyMessage) decodedWrite.getMessage()).getProperties().get("threshold")).intValue());
+
+        FunctionInvokeMessage function = new FunctionInvokeMessage();
+        function.deviceId("test-device");
+        function.messageId("msg-fn");
+        function.functionId("restart");
+        function.addInput("mode", "soft");
+        TopicPayload functionPayload = JetLinksTopicMessageCodec.encode(ObjectMappers.JSON_MAPPER, moduleMessage("board", function, "msg-fn"));
+        assertEquals("/module/board/function/invoke", functionPayload.getTopic());
+        DeviceModuleMessage decodedFunction = (DeviceModuleMessage) JetLinksTopicMessageCodec.decode(ObjectMappers.JSON_MAPPER, functionPayload.getTopic(), functionPayload.getPayload());
+        assertTrue(decodedFunction.getMessage() instanceof FunctionInvokeMessage);
+        assertEquals("restart", ((FunctionInvokeMessage) decodedFunction.getMessage()).getFunctionId());
+    }
+
+    @Test
+    public void testModuleRepliesKeepMessageId() {
+        ReadPropertyMessageReply readReply = ReadPropertyMessageReply.create();
+        readReply.messageId("msg-read");
+        readReply.success(Map.of("temperature", 36));
+        TopicPayload readPayload = JetLinksTopicMessageCodec.encode(ObjectMappers.JSON_MAPPER, moduleMessage("board", readReply, "msg-read"));
+        assertEquals("/module/board/properties/read/reply", readPayload.getTopic());
+        DeviceModuleMessage decodedRead = (DeviceModuleMessage) JetLinksTopicMessageCodec.decode(ObjectMappers.JSON_MAPPER, readPayload.getTopic(), readPayload.getPayload());
+        assertEquals("msg-read", decodedRead.getMessageId());
+        assertTrue(decodedRead.getMessage() instanceof ReadPropertyMessageReply);
+        assertEquals("msg-read", ((ReadPropertyMessageReply) decodedRead.getMessage()).getMessageId());
+
+        WritePropertyMessageReply writeReply = new WritePropertyMessageReply();
+        writeReply.messageId("msg-write");
+        writeReply.success();
+        assertEquals("/module/board/properties/write/reply", JetLinksTopicMessageCodec.encode(ObjectMappers.JSON_MAPPER, moduleMessage("board", writeReply, "msg-write")).getTopic());
+
+        FunctionInvokeMessageReply functionReply = new FunctionInvokeMessageReply();
+        functionReply.messageId("msg-fn");
+        functionReply.setFunctionId("restart");
+        functionReply.success();
+        assertEquals("/module/board/function/invoke/reply", JetLinksTopicMessageCodec.encode(ObjectMappers.JSON_MAPPER, moduleMessage("board", functionReply, "msg-fn")).getTopic());
+    }
+
+    private DeviceModuleMessage moduleMessage(String module, DeviceMessage inner, String messageId) {
+        DeviceModuleMessage message = new DeviceModuleMessage();
+        message.deviceId("test-device");
+        message.module(module);
+        message.messageId(messageId);
+        message.message(inner);
+        return message;
+    }
+
 }


### PR DESCRIPTION
## 变更目的

为设备增加“模块”能力：模块归属于父设备，不作为子设备或独立物类型；支持模块编码、模块 Thing、模块级物模型、模块属性/事件存储查询，以及标准/官方协议模块 Topic。

## 设计边界

- 设备模块不是子设备，不参与独立认证、会话、在线、固件、子设备拓扑或独立权限。
- 模块物模型只继承父设备/产品 metadata 中 `modules[moduleCode]` 对应模块物模型。
- 模块操作走 `ThingModuleMessage` / `DeviceModuleMessage`。
- 模块属性/事件使用独立 row-shaped 表；column mode 下也回退到模块 row-shaped 表。
- 模块日志不单独建表，复用父设备日志。
- 事件值内部字段搜索 / JSONB 深度索引不是本次交付范围。
- 未改造协议包不自动支持模块消息。

## 验证

已在 detached clean worktrees 中仅应用设备模块 patch 并执行 PR 包级门禁：

```bash
bash .ai/device-module-release/run-pr-package-gates.sh
```

结果：

```text
OK: device module PR package gates passed on detached clean worktrees.
SUMMARY audit_mode=worktree-diff actual_diff_files=68 extra_files=0
OK: all diff files are within device module release file list.
```

覆盖：core/supports、device-manager、things-component、timescaledb Testcontainers、标准协议、官方协议、manifest、patch apply、自检与 diff 边界审计。

## 关联 PR

该能力为多仓库联动发布，请按依赖顺序合并：

1. jetlinks-core
2. jetlinks-supports
3. jetlinks-components
4. device-manager
5. jetlinks-protocols
6. jetlinks-official-protocol
7. jetlinks-ultimate 发布材料
